### PR TITLE
CA_Gag: admin chat block enhancement with new CVar `ca_gag_block_admin_chat`

### DIFF
--- a/cstrike/addons/amxmodx/configs/plugins/ChatAdditions/CA_Gag.cfg
+++ b/cstrike/addons/amxmodx/configs/plugins/ChatAdditions/CA_Gag.cfg
@@ -69,3 +69,9 @@ ca_gag_sound_error "buttons/button2.wav"
 // -
 // Default: "1"
 ca_gag_block_nickname_change "1"
+
+// Also block adminchat if admin gagged
+//  0 = no restrictions
+// -
+// Default: "1"
+ca_gag_block_admin_chat "1"

--- a/cstrike/addons/amxmodx/scripting/CA_Gag.sma
+++ b/cstrike/addons/amxmodx/scripting/CA_Gag.sma
@@ -31,7 +31,7 @@ new ca_gag_times[64],
   ca_gag_remove_only_own_gag,
   ca_gag_sound_ok[128],
   ca_gag_sound_error[128],
-  bool: ca_gag_block_nickname_change
+  bool: ca_gag_block_nickname_change,
   bool: ca_gag_block_admin_chat
 
 new g_dummy, g_itemInfo[64], g_itemName[128]

--- a/cstrike/addons/amxmodx/scripting/CA_Gag.sma
+++ b/cstrike/addons/amxmodx/scripting/CA_Gag.sma
@@ -32,6 +32,7 @@ new ca_gag_times[64],
   ca_gag_sound_ok[128],
   ca_gag_sound_error[128],
   bool: ca_gag_block_nickname_change
+  bool: ca_gag_block_admin_chat
 
 new g_dummy, g_itemInfo[64], g_itemName[128]
 enum {
@@ -193,6 +194,13 @@ Register_CVars() {
         0 = no restrictions"
     ),
     ca_gag_block_nickname_change
+  )
+
+  bind_pcvar_num(create_cvar("ca_gag_block_admin_chat", "1",
+      .description = "Also block adminchat if admin gagged\n \
+        0 = no restrictions"
+    ),
+    ca_gag_block_admin_chat
   )
 }
 
@@ -1270,7 +1278,7 @@ public CA_Client_ChangeName(const id, const newName[]) {
 
 public ClCmd_adminSay(const id) {
   new bool: hasBlock = (g_currentGags[id][gd_reason][r_flags] & gagFlag_Say)
-  if(!hasBlock) {
+  if(!hasBlock || !ca_gag_block_admin_chat) {
     return CA_CONTINUE
   }
 

--- a/cstrike/addons/amxmodx/scripting/CA_Gag.sma
+++ b/cstrike/addons/amxmodx/scripting/CA_Gag.sma
@@ -44,6 +44,13 @@ new g_fwd_gag_setted,
   g_fwd_gag_removed,
   g_ret
 
+new const g_adminChatCmds[][] = {
+  "amx_say", "amx_asay", "amx_chat", "amx_psay",
+  "amx_teamsay", "amx_bsay", "amx_bsay2", "amx_csay",
+  "amx_csay2", "amx_rsay", "amx_rsay2", "amx_tsay",
+  "amx_tsay2"
+}
+
 public stock const PluginName[] = "CA: Gag"
 public stock const PluginVersion[] = CA_VERSION
 public stock const PluginAuthor[] = "Sergey Shorokhov"
@@ -97,8 +104,8 @@ public plugin_init() {
   register_clcmd("amx_gagmenu", "ClCmd_Gag", (accessFlags | accessFlagsHigh), .FlagManager = false)
   register_clcmd("say", "ClCmd_Say", (accessFlags | accessFlagsHigh), .FlagManager = false)
 
-  register_clcmd("amx_tsay", "ClCmd_adminSay", ADMIN_ALL)
-  register_clcmd("amx_csay", "ClCmd_adminSay", ADMIN_ALL)
+  for(new i; i < sizeof g_adminChatCmds; i++)
+    register_clcmd(g_adminChatCmds[i], "ClCmd_adminSay", ADMIN_CHAT);
 
   CA_Log(logLevel_Debug, "[CA]: Gag initialized!")
 


### PR DESCRIPTION
Expanded functionality for blocking admin chat:

- Added cvar if you don't want block admin chat when admin has gag
- Added support of OciXCrom's adminchat 