### PR TITLE
GAG_API: Add more params for forwards

### DIFF
--- a/cstrike/addons/amxmodx/scripting/CA_Gag.sma
+++ b/cstrike/addons/amxmodx/scripting/CA_Gag.sma
@@ -1508,9 +1508,19 @@ static bool: Gag_Save(const id, const target, const time, const flags, const exp
 
   ExecuteForward(g_fwd_gag_setted, g_ret,
     target,
+    gag[gd_name],
+    gag[gd_authID],
+    gag[gd_IP],
+
+    gag[gd_adminName],
+    gag[gd_adminAuthID],
+    gag[gd_adminIP],
+
     gag[gd_reason][r_name],
     gag[gd_reason][r_time],
-    gag[gd_reason][r_flags]
+    gag[gd_reason][r_flags],
+
+    gag[gd_expireAt]
   )
 
   if(g_ret == CA_SUPERCEDE) {
@@ -1566,7 +1576,12 @@ static Gag_Expired(const id) {
 
 
 Register_Forwards() {
-  g_fwd_gag_setted = CreateMultiForward("CA_gag_setted", ET_STOP, FP_CELL, FP_STRING, FP_CELL, FP_CELL)
+  g_fwd_gag_setted = CreateMultiForward("CA_gag_setted", ET_STOP,
+    FP_CELL, FP_STRING, FP_STRING, FP_STRING,
+    FP_STRING, FP_STRING, FP_STRING,
+    FP_STRING, FP_CELL, FP_CELL,
+    FP_CELL
+  )
   g_fwd_gag_removed = CreateMultiForward("CA_gag_removed", ET_STOP, FP_CELL, FP_STRING, FP_CELL, FP_CELL)
 }
 

--- a/cstrike/addons/amxmodx/scripting/include/CA_GAG_API.inc
+++ b/cstrike/addons/amxmodx/scripting/include/CA_GAG_API.inc
@@ -198,7 +198,7 @@ native bool: ca_remove_user_gag(const index);
  * @param adminAuthID   Admin authID
  * @param adminIP       Admin IP
  * @param reason        Reason
- * @param time          Time (in minutes)
+ * @param time          Time (in seconds)
  * @param flags         Flags (chat, teamChat, voice)
  * @param expireAt      Time when gag expire
  *
@@ -215,7 +215,7 @@ forward CA_gag_setted(
  *
  * @param target    Target index
  * @param target    Reason
- * @param minutes   Time (in minutes)
+ * @param minutes   Time (in seconds)
  * @param flags     Flags (chat, teamChat, voice)
  *
  * @return              Return CA_SUPERCEDE for prevent Gag remove.

--- a/cstrike/addons/amxmodx/scripting/include/CA_GAG_API.inc
+++ b/cstrike/addons/amxmodx/scripting/include/CA_GAG_API.inc
@@ -187,6 +187,11 @@ native bool: ca_has_user_gag(const index);
  */
 native bool: ca_remove_user_gag(const index);
 
+forward CA_gag_setted(
+  const target, name[], authID[], IP[],
+  adminName[], adminAuthID[], adminIP[],
+  reason[], time, gag_flags_s: flags,
+  expireAt);
 
 forward CA_gag_setted(const target, reason[], minutes, gag_flags_s: flags);
 forward CA_gag_removed(const target, reason[], minutes, gag_flags_s: flags);

--- a/cstrike/addons/amxmodx/scripting/include/CA_GAG_API.inc
+++ b/cstrike/addons/amxmodx/scripting/include/CA_GAG_API.inc
@@ -187,11 +187,37 @@ native bool: ca_has_user_gag(const index);
  */
 native bool: ca_remove_user_gag(const index);
 
+/**
+ * Called on Gag save.
+ *
+ * @param target        Targed index
+ * @param name          Targed name
+ * @param authID        Targed AuthID
+ * @param IP            Targed IP
+ * @param adminName     Admin name
+ * @param adminAuthID   Admin authID
+ * @param adminIP       Admin IP
+ * @param reason        Reason
+ * @param time          Time (in minutes)
+ * @param flags         Flags (chat, teamChat, voice)
+ * @param expireAt      Time when gag expire
+ *
+ * @return              Return CA_SUPERCEDE for prevent Gag.
+ */
 forward CA_gag_setted(
   const target, name[], authID[], IP[],
   adminName[], adminAuthID[], adminIP[],
   reason[], time, gag_flags_s: flags,
   expireAt);
 
-forward CA_gag_setted(const target, reason[], minutes, gag_flags_s: flags);
+/**
+ * Called on gag remove action.
+ *
+ * @param target    Target index
+ * @param target    Reason
+ * @param minutes   Time (in minutes)
+ * @param flags     Flags (chat, teamChat, voice)
+ *
+ * @return              Return CA_SUPERCEDE for prevent Gag remove.
+ */
 forward CA_gag_removed(const target, reason[], minutes, gag_flags_s: flags);


### PR DESCRIPTION
New `CA_gag_setted` params:

```sourcepawn
/**
 * Called on Gag save.
 *
 * @param target        Targed index
 * @param name          Targed name
 * @param authID        Targed AuthID
 * @param IP            Targed IP
 * @param adminName     Admin name
 * @param adminAuthID   Admin authID
 * @param adminIP       Admin IP
 * @param reason        Reason
 * @param time          Time (in minutes)
 * @param flags         Flags (chat, teamChat, voice)
 * @param expireAt      Time when gag expire
 *
 * @return              Return CA_SUPERCEDE to prevent Gag.
 */
forward CA_gag_setted(
  const target, name[], authID[], IP[],
  adminName[], adminAuthID[], adminIP[],
  reason[], time, gag_flags_s: flags,
  expireAt);

```




Test plugin
```sourcepawn
#include <amxmodx>
#include <CA_GAG_API>

#pragma dynamic 600000
#pragma ctrlchar '\'

/**
 * Called on Gag save.
 *
 * @param target        Targed index
 * @param name          Targed name
 * @param authID        Targed AuthID
 * @param IP            Targed IP
 * @param adminName     Admin name
 * @param adminAuthID   Admin authID
 * @param adminIP       Admin IP
 * @param reason        Reason
 * @param time          Time (in minutes)
 * @param flags         Flags (chat, teamChat, voice)
 * @param expireAt      Time when gag expire
 *
 * @return              Return CA_SUPERCEDE for prevent Gag.
 */
public CA_gag_setted(
  const target, name[], authID[], IP[],
  adminName[], adminAuthID[], adminIP[],
  reason[], time, gag_flags_s: flags,
  expireAt) {

  server_print("CA_gag_setted():\n\
    \t target=%i, name=`%s`, authID=`%s`, IP=`%s`,\n\
    \t adminName=`%s`, adminAuthID=`%s`, adminIP=`%s`,\n\
    \t reason=`%s`, time=%i, flags=%i,\n\
    \t expireAt=%i\n\
  ",
    target, name, authID, IP,
    adminName, adminAuthID, adminIP,
    reason, time, flags,
    expireAt
  )
}

/**
 * Called on gag remove action.
 *
 * @param target    Target index
 * @param target    Reason
 * @param minutes   Time (in minutes)
 * @param flags     Flags (chat, teamChat, voice)
 *
 * @return              Return CA_SUPERCEDE for prevent Gag remove.
 */
public CA_gag_removed(const target, reason[], minutes, gag_flags_s: flags) {
  server_print("CA_gag_removed():\n\
    \t target=%i, reason=`%s`, minutes=%i, flags=%i\n\
  ",
    target, reason, minutes, flags
  )
}
```

```cpp
CA_gag_setted():
         target=2, name=`[Komandantes]`, authID=`STEAM_3:0:750139587`, IP=`127.0.0.1`,
         adminName=`> Sergey Shorokhov;`, adminAuthID=`STEAM_0:0:56777063`, adminIP=`10.211.55.11`,
         reason=`Маты / оскорбления`, time=600, flags=7,
L 06/28/2021 - 18:20:49: Player gag saved {'[Komandantes]', 'STEAM_3:0:750139587', '127.0.0.1', 'Маты / оскорбления', '> Sergey Shorokhov;', 'STEAM_0:0:56777063', '10.211.55.11', 1624893649, 1624894249, 7} (queryTime: '0.000' sec)
L 06/28/2021 - 18:20:49: Gag: "> Sergey Shorokhov;" add gag to "[Komandantes]" (type:"abc") (time:"10 minutes") (reason:"Маты / оскорбления")
CA_gag_removed():
         target=2, reason=`Маты / оскорбления`, minutes=600, flags=7

L 06/28/2021 - 18:20:53: Player gag removed { } (queryTime: '0.097' sec)
```