### PR TITLE
new CVar: `ca_gag_common_chat_block`

### DIFF
--- a/cstrike/addons/amxmodx/configs/plugins/ChatAdditions/CA_Gag.cfg
+++ b/cstrike/addons/amxmodx/configs/plugins/ChatAdditions/CA_Gag.cfg
@@ -75,3 +75,11 @@ ca_gag_block_nickname_change "1"
 // -
 // Default: "1"
 ca_gag_block_admin_chat "1"
+
+// Don't separate `say` & `say_team` chats
+//  0 = disabled
+// -
+// Default: "1"
+ca_gag_common_chat_block "1"
+
+

--- a/cstrike/addons/amxmodx/scripting/CA_Gag.sma
+++ b/cstrike/addons/amxmodx/scripting/CA_Gag.sma
@@ -1558,7 +1558,7 @@ static bool: IsTargetHasImmunity(const id, const target) {
   return false
 }
 
-static Get_GagFlags_Names(const gag_flags_s: flags) {
+static Get_GagFlags_Names(gag_flags_s: flags) {
   // TODO: ML this
 
   new buffer[64]
@@ -1566,8 +1566,8 @@ static Get_GagFlags_Names(const gag_flags_s: flags) {
     "Chat", "Team chat", "Voice"
   }
 
-  if(ca_gag_common_chat_block && bool: (flags & gagFlag_SayTeam))
-    flags &= ~gagFlag_SayTeam
+  if(ca_gag_common_chat_block && (flags & gagFlag_SayTeam))
+    flags ^= gagFlag_SayTeam
 
   for(new i = 0; i < sizeof(GAG_FLAGS_STR); i++) {
     if(flags & gag_flags_s: (1 << i)) {

--- a/cstrike/addons/amxmodx/scripting/CA_Gag.sma
+++ b/cstrike/addons/amxmodx/scripting/CA_Gag.sma
@@ -1566,6 +1566,9 @@ static Get_GagFlags_Names(const gag_flags_s: flags) {
     "Chat", "Team chat", "Voice"
   }
 
+  if(ca_gag_common_chat_block && bool: (flags & gagFlag_SayTeam))
+    flags &= ~gagFlag_SayTeam
+
   for(new i = 0; i < sizeof(GAG_FLAGS_STR); i++) {
     if(flags & gag_flags_s: (1 << i)) {
       strcat(buffer, fmt("%s + ", GAG_FLAGS_STR[i]), charsmax(buffer));

--- a/cstrike/addons/amxmodx/scripting/CA_Gag.sma
+++ b/cstrike/addons/amxmodx/scripting/CA_Gag.sma
@@ -32,7 +32,8 @@ new ca_gag_times[64],
   ca_gag_sound_ok[128],
   ca_gag_sound_error[128],
   bool: ca_gag_block_nickname_change,
-  bool: ca_gag_block_admin_chat
+  bool: ca_gag_block_admin_chat,
+  bool: ca_gag_common_chat_block
 
 new g_dummy, g_itemInfo[64], g_itemName[128]
 
@@ -206,6 +207,13 @@ Register_CVars() {
         0 = no restrictions"
     ),
     ca_gag_block_admin_chat
+  )
+
+  bind_pcvar_num(create_cvar("ca_gag_common_chat_block", "1",
+      .description = "Don't separate `say` & `say_team` chats\n \
+        0 = disabled"
+    ),
+    ca_gag_common_chat_block
   )
 }
 

--- a/cstrike/addons/amxmodx/scripting/CA_Gag.sma
+++ b/cstrike/addons/amxmodx/scripting/CA_Gag.sma
@@ -646,10 +646,12 @@ static MenuShow_SelectFlags(const id) {
     (gagFlags & gagFlag_Say) ? " \\r+\\w " : "-"),
     fmt("%i", gagFlag_Say)
   )
-  menu_additem(menu, fmt("%L [ %s ]", id, "Gag_MenuItem_PropSayTeam",
-    (gagFlags & gagFlag_SayTeam) ? " \\r+\\w " : "-"),
-    fmt("%i", gagFlag_SayTeam)
-  )
+  if(!ca_gag_common_chat_block) {
+    menu_additem(menu, fmt("%L [ %s ]", id, "Gag_MenuItem_PropSayTeam",
+      (gagFlags & gagFlag_SayTeam) ? " \\r+\\w " : "-"),
+      fmt("%i", gagFlag_SayTeam)
+    )
+  }
   menu_additem(menu, fmt("%L [ %s ]", id, "Gag_MenuItem_PropVoice",
     (gagFlags & gagFlag_Voice) ? " \\r+\\w " : "-"),
     fmt("%i", gagFlag_Voice)
@@ -726,7 +728,9 @@ public MenuHandler_SelectFlags(const id, const menu, const item) {
   new itemIndex = strtol(g_itemInfo)
 
   switch(itemIndex) {
-    case gagFlag_Say:     g_adminTempData[id][gd_reason][r_flags] ^= gagFlag_Say
+    case gagFlag_Say: {
+      g_adminTempData[id][gd_reason][r_flags] ^= (!ca_gag_common_chat_block ? gagFlag_Say : (gagFlag_Say | gagFlag_SayTeam))
+    }
     case gagFlag_SayTeam: g_adminTempData[id][gd_reason][r_flags] ^= gagFlag_SayTeam
     case gagFlag_Voice:   g_adminTempData[id][gd_reason][r_flags] ^= gagFlag_Voice
 
@@ -918,11 +922,15 @@ static MenuShow_EditGag(const id) {
     ),
     fmt("%i", gagFlag_Say)
   )
-  menu_additem(menu, fmt("%L [ %s ]", id, "Gag_MenuItem_PropSayTeam",
-      (gagFlags & gagFlag_SayTeam) ? " \\r+\\w " : "-"
-    ),
-    fmt("%i", gagFlag_SayTeam)
-  )
+
+  if(!ca_gag_common_chat_block) {
+    menu_additem(menu, fmt("%L [ %s ]", id, "Gag_MenuItem_PropSayTeam",
+        (gagFlags & gagFlag_SayTeam) ? " \\r+\\w " : "-"
+      ),
+      fmt("%i", gagFlag_SayTeam)
+    )
+  }
+
   menu_additem(menu, fmt("%L [ %s ]", id, "Gag_MenuItem_PropVoice",
       (gagFlags & gagFlag_Voice) ? " \\r+\\w " : "-"
     ),
@@ -1307,7 +1315,7 @@ public CA_Client_SayTeam(id, const message[]) {
   if(CmdRouter(id, message))
     return PLUGIN_CONTINUE
 
-  new bool: hasBlock = (g_currentGags[id][gd_reason][r_flags] & gagFlag_SayTeam)
+  new bool: hasBlock = bool: (g_currentGags[id][gd_reason][r_flags] & (ca_gag_common_chat_block ? gagFlag_SayTeam : gagFlag_Say))
 
   if(!hasBlock) {
     return CA_CONTINUE


### PR DESCRIPTION
Reslove #221

```cpp
// Don't separate `say` & `say_team` chats
//  0 = disabled
// -
// Default: "1"
ca_gag_common_chat_block "1"
```